### PR TITLE
payton: Move fingerprint HAL to class hal

### DIFF
--- a/payton/proprietary/vendor/etc/init/android.hardware.biometrics.fingerprint@2.1-service.rc
+++ b/payton/proprietary/vendor/etc/init/android.hardware.biometrics.fingerprint@2.1-service.rc
@@ -2,7 +2,7 @@ service fps_hal /vendor/bin/hw/android.hardware.biometrics.fingerprint@2.1-fpcse
     # "class hal" causes a race condition on some devices due to files created
     # in /data. As a workaround, postpone startup until later in boot once
     # /data is mounted.
-    class late_start
+    class hal
     user system
     # fingerp:9015
     group system uhid input 9015


### PR DESCRIPTION
On fde-enabled devices the fingerprint hal needs to be started earlier
to fix the pin dialog during boot.

Inspired by https://github.com/LineageOS/android_device_motorola_montana/commit/65d96d19200548db4cf343a206e0c3e02e3c77c0